### PR TITLE
Board: pins and analogPins properties need to be defined on initialization

### DIFF
--- a/lib/board-io.js
+++ b/lib/board-io.js
@@ -22,6 +22,8 @@ function BoardIO(opts) {
 
   // expose isReady property
   var isReady = false;
+  // these are the indexes of analog pins in the this.pins array
+  var analogPins = [];
 
   // child classes will fill this array
   this._pins = [];
@@ -32,9 +34,6 @@ function BoardIO(opts) {
     // make sure we have some pins
     check.verify.array(this._pins, "this._pins should be an array!");
     check.verify.not.length(this._pins, 0, "Please populate this._pins with pins!");
-
-    // these are the indexes of analog pins in the this.pins array
-    var analogPins = [];
 
     this._pins.forEach(function(pin, index) {
       // make sure that the right properties have been set
@@ -50,27 +49,24 @@ function BoardIO(opts) {
       }
     }, this);
 
-    Object.defineProperties(this, {
-      pins: {
-        enumerable: true,
-        get: function() {
-          return this._pins;
-        }
-      },
-      analogPins: {
-        enumerable: true,
-        get: function() {
-          return analogPins;
-        }
-      }
-    });
-
     if (this._quiet) {
       log = function() {};
     }
   });
 
   Object.defineProperties(this, {
+    pins: {
+      enumerable: true,
+      get: function() {
+        return this._pins;
+      }
+    },
+    analogPins: {
+      enumerable: true,
+      get: function() {
+        return analogPins;
+      }
+    },    
     isReady: {
       get: function() {
         return isReady;


### PR DESCRIPTION
The own-instance properties are expected to exist on initialization of a board instance. The values within can be populated asynchronously (available when "ready" emits)